### PR TITLE
fix: Fix link to pixi

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/devcontainers/base:jammy
 
 ARG PIXI_VERSION=v0.55.0
 
-RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-gnu" \
+RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
     && chmod +x /usr/local/bin/pixi \
     && pixi info
 


### PR DESCRIPTION
This pull request makes a minor update to the `.devcontainer/Dockerfile` by changing the download target for the `pixi` binary to use the `linux-musl` variant instead of `linux-gnu`. This change may improve compatibility with certain environments.

- Updated the `curl` command in `.devcontainer/Dockerfile` to download the `pixi` binary for `unknown-linux-musl` instead of `unknown-linux-gnu`.