### PR TITLE
feat: add freeform general issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -24,3 +24,8 @@ issue_templates:
     description: Report slowness or excessive resource use.
     labels: [performance]
     body: performance_issue.yml
+  - name: General issue
+    id: general
+    description: Open a general issue that doesn't fit the other categories.
+    labels: [triage]
+    body: general.yml

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,17 @@
+name: "📝 General issue"
+description: "Open a general issue that doesn't fit the other categories."
+title: "<short summary>"
+labels: ["triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue, question, or idea in your own words.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any links, screenshots, or other details that might help.


### PR DESCRIPTION
## Summary
- Adds a new **General issue** template (`.github/ISSUE_TEMPLATE/general.yml`) for issues that don't fit existing categories
- Only two fields: a required description and optional additional context, keeping it lightweight and freeform
- Registers the template in `config.yml` so it appears in the issue chooser

## Test plan
- [x] Verify the new "General issue" option appears in the GitHub issue template chooser
- [x] Confirm the form renders with the description and context fields
- [x] Ensure existing templates (bug, feature, docs, performance) still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new general issue template as an additional option for reporting issues, with dedicated fields for description and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->