### PR TITLE
ci: bump pixi version from v0.59.0 to v0.63.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.59.0
+          pixi-version: v0.63.2
           environments: ${{ matrix.python-version }}
 
       - name: Print pixi version


### PR DESCRIPTION
## Description

Bump the CI pixi version from `v0.59.0` to `v0.63.2` in `.github/workflows/ci.yml`.

The pinned `v0.59.0` cannot parse lock files generated by pixi `0.63.2`

Resolves #145

## Checklist

- [x] I ran `pre-commit run --all-files` and all checks pass
- [ ] Tests added/updated where needed
- [ ] Docs added/updated if applicable
- [x] I have linked the issue this PR closes (if any)

## Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [x]      |
| Other (explain)  | [ ]      |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration tooling to a newer version for improved build performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->