### PR TITLE
feat: Cloud SQL Public IP Allowlist via Pulumi Secrets

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -206,6 +206,32 @@ pixi run -e deployment cloud-plan
 pixi run -e deployment cloud-deploy
 ```
 
+### Managing Cloud SQL Access (IP Allowlist)
+
+Public IP access to the staging database is restricted via an allowlist stored
+as a Pulumi stack secret. To update the list of authorized networks:
+
+1.  **Navigate to the infrastructure directory:**
+
+    ```bash
+    cd deployment/cloud/gcp/infrastructure
+    ```
+
+2.  **Set the authorized networks secret:** Replace the example below with your
+    desired names and IPs. Note that this command replaces the entire list.
+
+    ```bash
+    export PULUMI_CONFIG_PASSPHRASE=""
+    pixi run -e deployment pulumi config set --secret db_authorized_networks \
+      '[{"name":"office", "value":"1.2.3.4/32"}, {"name":"dev-personal", "value":"5.6.7.8/32"}]' \
+      --stack staging
+    ```
+
+3.  **Deploy the changes:**
+    ```bash
+    pixi run -e deployment cloud-deploy
+    ```
+
 ### Build & Push Container Images
 
 Build container images (`webservice`, `pipeline`) via Cloud Build:

--- a/deployment/cloud/gcp/infrastructure/Pulumi.staging.yaml
+++ b/deployment/cloud/gcp/infrastructure/Pulumi.staging.yaml
@@ -1,0 +1,6 @@
+encryptionsalt: v1:Bq7WJosg4dA=:v1:+A7xextaV2fhD9Tk:ln2GwdhrRnpxJavu/VvjSvZk5JwC2g==
+config:
+  ca-biositing-infrastructure:db_authorized_networks:
+    secure: v1:JiBpEOhwJp1tW71U:UbNDr+N1MJDpUjCPnER6TpccBOZrqLkVa+qLzIjvLg/fROwQTj3eeZoZDQy36BVQ41a7cju/FBpKWn1OktVre1Nf
+  gcp:project: biocirv-470318
+  gcp:region: us-west1

--- a/deployment/cloud/gcp/infrastructure/Pulumi.yaml
+++ b/deployment/cloud/gcp/infrastructure/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: ca-biositing-infrastructure
+runtime: python
+description: GCP Infrastructure for ca-biositing
+backend:
+  url: gs://biocirv-470318-pulumi-state

--- a/deployment/cloud/gcp/infrastructure/cloud_sql.py
+++ b/deployment/cloud/gcp/infrastructure/cloud_sql.py
@@ -11,6 +11,7 @@ from config import (
     DB_INSTANCE_NAME,
     DB_NAME,
     PREFECT_DB_NAME,
+    get_db_authorized_networks,
 )
 
 
@@ -25,6 +26,7 @@ def create_cloud_sql(
     depends_on: Sequence[pulumi.Resource] | None = None,
 ) -> CloudSQLResources:
     """Create Cloud SQL instance with databases."""
+    auth_networks = get_db_authorized_networks()
     instance = gcp.sql.DatabaseInstance(
         "staging-db-instance",
         name=DB_INSTANCE_NAME,
@@ -38,6 +40,13 @@ def create_cloud_sql(
             ip_configuration=gcp.sql.DatabaseInstanceSettingsIpConfigurationArgs(
                 ipv4_enabled=True,
                 ssl_mode="ENCRYPTED_ONLY",
+                authorized_networks=[
+                    gcp.sql.DatabaseInstanceSettingsIpConfigurationAuthorizedNetworkArgs(
+                        name=net["name"],
+                        value=net["value"],
+                    )
+                    for net in auth_networks
+                ],
             ),
             backup_configuration=gcp.sql.DatabaseInstanceSettingsBackupConfigurationArgs(
                 enabled=True,

--- a/deployment/cloud/gcp/infrastructure/config.py
+++ b/deployment/cloud/gcp/infrastructure/config.py
@@ -2,6 +2,7 @@
 
 import os
 
+import pulumi
 from pulumi import automation as auto
 
 # Project and stack settings
@@ -22,6 +23,12 @@ DB_USER = "biocirv_user"
 
 # Read-only users
 READONLY_USERS = ["biocirv_readonly"]
+
+# Authorized Networks for Cloud SQL
+# This is a list of dicts: [{"name": "office", "value": "203.0.113.1/32"}]
+# Pulumi config allows us to share these securely across the team.
+def get_db_authorized_networks():
+    return pulumi.Config().get_object("db_authorized_networks") or []
 
 # Container images — override with env vars to use digest/commit-based tags
 # instead of :latest (which Pulumi cannot detect changes for).

--- a/deployment/cloud/gcp/infrastructure/deploy.py
+++ b/deployment/cloud/gcp/infrastructure/deploy.py
@@ -83,11 +83,7 @@ def get_stack() -> auto.Stack:
         project_name=PROJECT_NAME,
         program=pulumi_program,
         opts=auto.LocalWorkspaceOptions(
-            project_settings=auto.ProjectSettings(
-                name=PROJECT_NAME,
-                runtime="python",
-                backend=auto.ProjectBackend(url=BACKEND_URL),
-            ),
+            work_dir=".",
         ),
     )
     configure_stack(stack)

--- a/docs/pr/20260302_cloud_sql_ip_allowlist.md
+++ b/docs/pr/20260302_cloud_sql_ip_allowlist.md
@@ -1,0 +1,62 @@
+# PR: Cloud SQL Public IP Allowlist via Pulumi Secrets
+
+## Overview
+
+This PR implements a secure, team-shareable public IP allowlist for the staging
+Cloud SQL instance. By using Pulumi Stack Secrets, we can manage access for
+individual developers and offices without exposing sensitive IP addresses in
+plain text within the repository.
+
+## Key Changes
+
+### 1. Pulumi CLI Integration
+
+- Created `deployment/cloud/gcp/infrastructure/Pulumi.yaml` to allow the
+  standard Pulumi CLI to interact with the existing Automation API project. This
+  is necessary for managing stack-level configuration and secrets.
+
+### 2. Secure Configuration Management
+
+- **Secrets**: Implemented `db_authorized_networks` as a Pulumi stack secret.
+  This stores a JSON list of authorized networks (e.g.,
+  `[{"name": "dev-access", "value": "<ALLOWED_IP>/32"}]`).
+- **Lazy Evaluation**: Updated `deployment/cloud/gcp/infrastructure/config.py`
+  to use a `get_db_authorized_networks()` function. This ensures secrets are
+  fetched at runtime within the active Pulumi context rather than at module
+  import time.
+
+### 3. Infrastructure Updates
+
+- **Cloud SQL**: Modified `deployment/cloud/gcp/infrastructure/cloud_sql.py` to
+  map the authorized networks into the `DatabaseInstance` settings.
+- **Automation API Sync**: Updated
+  `deployment/cloud/gcp/infrastructure/deploy.py` to use `work_dir="."`. This
+  ensures that the programmatic deployment correctly identifies and loads the
+  local `Pulumi.staging.yaml` file and its associated secrets.
+
+## How to Manage the Allowlist
+
+Authorized networks are managed via the Pulumi CLI. From the
+`deployment/cloud/gcp/infrastructure` directory:
+
+```bash
+# Set the allowlist (replaces existing list)
+export PULUMI_CONFIG_PASSPHRASE=""
+pixi run -e deployment pulumi config set --secret db_authorized_networks '[{"name":"office", "value":"<OFFICE_IP>/32"}, {"name":"dev-personal", "value":"<DEV_IP>/32"}]' --stack staging
+```
+
+## Verification Results
+
+- **Pulumi Preview**: Confirmed that `pixi run cloud-plan` correctly retrieves
+  the encrypted secrets and identifies the required changes to the Cloud SQL
+  instance:
+
+  ```text
+  Diagnostics:
+    Authorized networks: [{'name': 'dev-access', 'value': '<ALLOWED_IP>/32'}]
+
+  ~ gcp:sql:DatabaseInstance staging-db-instance update [diff: ~settings]
+  ```
+
+- **Team Consistency**: Verified that if the secret is missing, it defaults to
+  an empty list, maintaining a "fail-closed" security posture.


### PR DESCRIPTION
<!--
  Pull Request Template
  =====================
  Provide a high-quality, concise description of your changes.
  PRs that follow this template are easier to review and merge.
-->

## Overview

This PR implements a secure, team-shareable public IP allowlist for the staging
Cloud SQL instance. By using Pulumi Stack Secrets, we can manage access for
individual developers and offices without exposing sensitive IP addresses in
plain text within the repository.

## Key Changes

### 1. Pulumi CLI Integration

- Created `deployment/cloud/gcp/infrastructure/Pulumi.yaml` to allow the
  standard Pulumi CLI to interact with the existing Automation API project. This
  is necessary for managing stack-level configuration and secrets.

### 2. Secure Configuration Management

- **Secrets**: Implemented `db_authorized_networks` as a Pulumi stack secret.
  This stores a JSON list of authorized networks (e.g.,
  `[{"name": "dev-access", "value": "<ALLOWED_IP>/32"}]`).
- **Lazy Evaluation**: Updated `deployment/cloud/gcp/infrastructure/config.py`
  to use a `get_db_authorized_networks()` function. This ensures secrets are
  fetched at runtime within the active Pulumi context rather than at module
  import time.

### 3. Infrastructure Updates

- **Cloud SQL**: Modified `deployment/cloud/gcp/infrastructure/cloud_sql.py` to
  map the authorized networks into the `DatabaseInstance` settings.
- **Automation API Sync**: Updated
  `deployment/cloud/gcp/infrastructure/deploy.py` to use `work_dir="."`. This
  ensures that the programmatic deployment correctly identifies and loads the
  local `Pulumi.staging.yaml` file and its associated secrets.

## How to Manage the Allowlist

Authorized networks are managed via the Pulumi CLI. From the
`deployment/cloud/gcp/infrastructure` directory:

```bash
# Set the allowlist (replaces existing list)
export PULUMI_CONFIG_PASSPHRASE=""
pixi run -e deployment pulumi config set --secret db_authorized_networks '[{"name":"office", "value":"<OFFICE_IP>/32"}, {"name":"dev-personal", "value":"<DEV_IP>/32"}]' --stack staging
```

## Verification Results

- **Pulumi Preview**: Confirmed that `pixi run cloud-plan` correctly retrieves
  the encrypted secrets and identifies the required changes to the Cloud SQL
  instance:

  ```text
  Diagnostics:
    Authorized networks: [{'name': 'dev-access', 'value': '<ALLOWED_IP>/32'}]

  ~ gcp:sql:DatabaseInstance staging-db-instance update [diff: ~settings]
  ```

- **Team Consistency**: Verified that if the secret is missing, it defaults to
  an empty list, maintaining a "fail-closed" security posture.


## ✅ Checklist

- [x] I ran `pre-commit run --all-files` and all checks pass
- [ ] Tests added/updated where needed
- [x] Docs added/updated if applicable
- [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

Resolves #\<issue-number>

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [x]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test



## 📝 Notes to reviewers

I have not yet deployed, but the cloud-plan looks good.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloud SQL public IP allowlist management capability with secure, runtime-configured network authorization.

* **Documentation**
  * Added comprehensive deployment documentation covering Cloud SQL access management, container image building, and database migration workflows.

* **Chores**
  * Established infrastructure-as-code configuration for GCP project and deployment state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->