### PR TITLE
refactor: Update old repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ca-biositing/
 
 ```bash
 # Clone the repository
-git clone https://github.com/uw-ssec/ca-biositing.git
+git clone https://github.com/sustainability-software-lab/ca-biositing.git
 cd ca-biositing
 
 # Install dependencies with Pixi
@@ -347,7 +347,7 @@ Most documentation should live in the relevant directories within the `docs`
 folder.
 
 When adding new pages to the documentation, make sure you update the
-[`mkdocs.yml` file](https://github.com/uw-ssec/ca-biositing/blob/main/mkdocs.yml)
+[`mkdocs.yml` file](https://github.com/sustainability-software-lab/ca-biositing/blob/main/mkdocs.yml)
 so they can be rendered on the website.
 
 If you need to add documentation referencing a file that lives elsewhere in the

--- a/docs/ca_biositing_local_setup.md
+++ b/docs/ca_biositing_local_setup.md
@@ -18,7 +18,7 @@ Docker infrastructure.
 ### Commands
 
 ```bash
-git clone https://github.com/uw-ssec/ca-biositing.git
+git clone https://github.com/sustainability-software-lab/ca-biositing.git
 cd ca-biositing
 pixi install
 pixi shell

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: CA-BioSiting
-repo_url: https://github.com/uw-ssec/ca-biositing
+repo_url: https://github.com/sustainability-software-lab/ca-biositing
 
 theme:
   name: material

--- a/src/ca_biositing/datamodels/README.md
+++ b/src/ca_biositing/datamodels/README.md
@@ -312,7 +312,7 @@ pixi run pre-commit run --files src/ca_biositing/datamodels/**/*
 - **Version**: 0.1.0
 - **Python**: >= 3.12
 - **License**: BSD License
-- **Repository**: <https://github.com/uw-ssec/ca-biositing>
+- **Repository**: <https://github.com/sustainability-software-lab/ca-biositing>
 
 ## Contributing
 

--- a/src/ca_biositing/datamodels/pyproject.toml
+++ b/src/ca_biositing/datamodels/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/uw-ssec/ca-biositing"
-Repository = "https://github.com/uw-ssec/ca-biositing.git"
-Issues = "https://github.com/uw-ssec/ca-biositing/issues"
+Homepage = "https://github.com/sustainability-software-lab/ca-biositing"
+Repository = "https://github.com/sustainability-software-lab/ca-biositing.git"
+Issues = "https://github.com/sustainability-software-lab/ca-biositing/issues"
 
 [tool.hatch.build.targets.wheel]
 only-include = ["ca_biositing"]

--- a/src/ca_biositing/pipeline/README.md
+++ b/src/ca_biositing/pipeline/README.md
@@ -326,7 +326,7 @@ following the project conventions.
 - **Version**: 0.1.0
 - **Python**: >= 3.12
 - **License**: BSD License
-- **Repository**: <https://github.com/uw-ssec/ca-biositing>
+- **Repository**: <https://github.com/sustainability-software-lab/ca-biositing>
 
 ## Contributing
 

--- a/src/ca_biositing/pipeline/pyproject.toml
+++ b/src/ca_biositing/pipeline/pyproject.toml
@@ -36,9 +36,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/uw-ssec/ca-biositing"
-Repository = "https://github.com/uw-ssec/ca-biositing.git"
-Issues = "https://github.com/uw-ssec/ca-biositing/issues"
+Homepage = "https://github.com/sustainability-software-lab/ca-biositing"
+Repository = "https://github.com/sustainability-software-lab/ca-biositing.git"
+Issues = "https://github.com/sustainability-software-lab/ca-biositing/issues"
 
 [tool.hatch.build.targets.wheel]
 only-include = ["ca_biositing"]

--- a/src/ca_biositing/webservice/README.md
+++ b/src/ca_biositing/webservice/README.md
@@ -204,7 +204,7 @@ def get_resources(session: Session = Depends(get_session)):
 - **Version**: 0.1.0
 - **Python**: >= 3.12
 - **License**: BSD License
-- **Repository**: <https://github.com/uw-ssec/ca-biositing>
+- **Repository**: <https://github.com/sustainability-software-lab/ca-biositing>
 
 ## Contributing
 

--- a/src/ca_biositing/webservice/pyproject.toml
+++ b/src/ca_biositing/webservice/pyproject.toml
@@ -33,9 +33,9 @@ dependencies = [
 
 
 [project.urls]
-Homepage = "https://github.com/uw-ssec/ca-biositing"
-Repository = "https://github.com/uw-ssec/ca-biositing.git"
-Issues = "https://github.com/uw-ssec/ca-biositing/issues"
+Homepage = "https://github.com/sustainability-software-lab/ca-biositing"
+Repository = "https://github.com/sustainability-software-lab/ca-biositing.git"
+Issues = "https://github.com/sustainability-software-lab/ca-biositing/issues"
 
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
This pull request updates all references to the project's GitHub repository, changing them from the old `uw-ssec` organization to the new `sustainability-software-lab` organization. This ensures consistency across documentation, configuration files, and metadata, aligning the project with its new home.

Repository reference updates:

* Updated repository URLs in `README.md` files across the project to point to `https://github.com/sustainability-software-lab/ca-biositing` instead of the previous `uw-ssec` location. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48) [[2]](diffhunk://#diff-9332c67ead5ff5d7a71180a3b7b15b00ba45c1fb2508c4220294ca55e9e9103fL315-R315) [[3]](diffhunk://#diff-536f01e25590c2063178b7d83ba861941d848416c3e60c6412416d35f61cd30dL329-R329) [[4]](diffhunk://#diff-af05d24c7dd18cd8b05e856124197e2afdb85578fe1376a1581416575fe6aa30L207-R207)
* Changed documentation links in `README.md` to reference the new repository, including the `mkdocs.yml` file for documentation navigation.
* Modified repository URLs in `pyproject.toml` files for `datamodels`, `pipeline`, and `webservice` to use the new organization and repository location. [[1]](diffhunk://#diff-8447f45625164bb6a8161c936769c122666e281291d90055c8b57b1aef108553L35-R37) [[2]](diffhunk://#diff-ce31eec066e7709e52e5ab9986a5406277dcf366cddc0ceba1cc3da638f63b22L39-R41) [[3]](diffhunk://#diff-3cc2dbaecb6cc5781976ce8c760859c4848ff45055a4947bea0f64b533279a18L36-R38)
* Updated the `repo_url` field in `mkdocs.yml` to the new repository URL.
* Changed clone instructions in documentation to use the new GitHub repository address.

These changes help ensure that all documentation, metadata, and configuration files accurately reflect the project's current repository location.
