### PR TITLE
fix: move CI pixi tasks to shell scripts for cross-platform compatibility

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -397,32 +397,38 @@ description = "Refresh Pulumi state from live GCP resources."
 # They read IMAGE_TAG from the environment (default: "latest").
 
 [feature.cloud.tasks.cloud-build-images-ci]
-cmd = "gcloud builds submit --config=deployment/cloud/gcp/cloudbuild-ci.yaml --substitutions=_IMAGE_TAG=${IMAGE_TAG:-latest} --project=biocirv-470318 ."
+cmd = "bash scripts/cloud-build-images-ci.sh"
+env = { IMAGE_TAG = "latest" }
 description = "Build and push Docker images to GCR with IMAGE_TAG (default: latest). Usage: IMAGE_TAG=abc1234 pixi run cloud-build-images-ci"
 
 [feature.cloud.tasks.cloud-deploy-direct]
-cmd = "PULUMI_CONFIG_PASSPHRASE='' python deployment/cloud/gcp/infrastructure/deploy.py up"
+cmd = "python deployment/cloud/gcp/infrastructure/deploy.py up"
+env = { PULUMI_CONFIG_PASSPHRASE = "" }
 description = "Deploy infrastructure via Pulumi (direct, no Docker). Reads IMAGE_TAG from env. For Linux/CI use."
 
 [feature.cloud.tasks.cloud-plan-direct]
-cmd = "PULUMI_CONFIG_PASSPHRASE='' python deployment/cloud/gcp/infrastructure/deploy.py preview"
+cmd = "python deployment/cloud/gcp/infrastructure/deploy.py preview"
+env = { PULUMI_CONFIG_PASSPHRASE = "" }
 description = "Preview infrastructure changes via Pulumi (direct, no Docker). For Linux/CI use."
 
 [feature.cloud.tasks.cloud-refresh-direct]
-cmd = "PULUMI_CONFIG_PASSPHRASE='' python deployment/cloud/gcp/infrastructure/deploy.py refresh"
+cmd = "python deployment/cloud/gcp/infrastructure/deploy.py refresh"
+env = { PULUMI_CONFIG_PASSPHRASE = "" }
 description = "Refresh Pulumi state from live GCP resources (direct, no Docker). For Linux/CI use."
 
 [feature.cloud.tasks.cloud-outputs-direct]
-cmd = "PULUMI_CONFIG_PASSPHRASE='' python deployment/cloud/gcp/infrastructure/deploy.py outputs"
+cmd = "python deployment/cloud/gcp/infrastructure/deploy.py outputs"
+env = { PULUMI_CONFIG_PASSPHRASE = "" }
 description = "Show Pulumi stack outputs (direct, no Docker). For Linux/CI use."
 
 [feature.cloud.tasks.cloud-migrate-ci]
-cmd = "gcloud run jobs update biocirv-alembic-migrate --image=gcr.io/biocirv-470318/pipeline:${IMAGE_TAG:-latest} --region=us-west1 && gcloud run jobs execute biocirv-alembic-migrate --region=us-west1 --wait"
+cmd = "bash scripts/cloud-migrate-ci.sh"
+env = { IMAGE_TAG = "latest" }
 description = "Update migration job image with IMAGE_TAG and execute. Usage: IMAGE_TAG=abc1234 pixi run cloud-migrate-ci"
 
 [feature.cloud.tasks.cloud-update-services]
-cmd = """gcloud run services update biocirv-prefect-worker --image=gcr.io/biocirv-470318/pipeline:${IMAGE_TAG:-latest} --region=us-west1 && \
-gcloud run services update biocirv-webservice --image=gcr.io/biocirv-470318/webservice:${IMAGE_TAG:-latest} --region=us-west1"""
+cmd = "bash scripts/cloud-update-services.sh"
+env = { IMAGE_TAG = "latest" }
 description = "Force new Cloud Run revisions with IMAGE_TAG. Usage: IMAGE_TAG=abc1234 pixi run cloud-update-services"
 
 [feature.gis.pypi-dependencies]

--- a/scripts/cloud-build-images-ci.sh
+++ b/scripts/cloud-build-images-ci.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and push Docker images to GCR with IMAGE_TAG substitution.
+# IMAGE_TAG defaults to "latest" if not set in the environment.
+
+gcloud builds submit \
+  --config=deployment/cloud/gcp/cloudbuild-ci.yaml \
+  --substitutions="_IMAGE_TAG=${IMAGE_TAG:-latest}" \
+  --project=biocirv-470318 \
+  .

--- a/scripts/cloud-migrate-ci.sh
+++ b/scripts/cloud-migrate-ci.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update migration job image with IMAGE_TAG and execute.
+# IMAGE_TAG defaults to "latest" if not set in the environment.
+
+gcloud run jobs update biocirv-alembic-migrate \
+  --image="gcr.io/biocirv-470318/pipeline:${IMAGE_TAG:-latest}" \
+  --region=us-west1
+
+gcloud run jobs execute biocirv-alembic-migrate \
+  --region=us-west1 \
+  --wait

--- a/scripts/cloud-update-services.sh
+++ b/scripts/cloud-update-services.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Force new Cloud Run revisions with IMAGE_TAG.
+# IMAGE_TAG defaults to "latest" if not set in the environment.
+
+gcloud run services update biocirv-prefect-worker \
+  --image="gcr.io/biocirv-470318/pipeline:${IMAGE_TAG:-latest}" \
+  --region=us-west1
+
+gcloud run services update biocirv-webservice \
+  --image="gcr.io/biocirv-470318/webservice:${IMAGE_TAG:-latest}" \
+  --region=us-west1


### PR DESCRIPTION
## Summary

- Fixes CI failure in `deploy-staging.yml` caused by pixi's built-in shell (deno_task_shell) not supporting bash's `${VAR:-default}` syntax
- Moves `cloud-build-images-ci`, `cloud-migrate-ci`, and `cloud-update-services` commands into bash scripts under `scripts/`
- Uses pixi's `env` field to set `IMAGE_TAG` and `PULUMI_CONFIG_PASSPHRASE` defaults instead of inline shell syntax

## Root cause

Pixi tasks run in deno_task_shell (cross-platform), not bash. The `${IMAGE_TAG:-latest}` parameter expansion is bash-specific and fails with:
```
× failed to parse shell script
╰─▶ Unexpected character.
      {IMAGE_TAG:-latest}
      ~
```

## Test plan

- [ ] PR preview job passes (Pulumi preview via `cloud-plan-direct`)
- [ ] After merge, `deploy-staging` workflow completes all 4 jobs successfully