### PR TITLE
fix: route GHCR images through Artifact Registry remote repo

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -538,7 +538,7 @@ mounted secret:
 
 ```bash
 gcloud run services update biocirv-prefect-worker \
-  --image=ghcr.io/sustainability-software-lab/ca-biositing/pipeline:latest \
+  --image=us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/pipeline:latest \
   --region=us-west1
 ```
 
@@ -661,7 +661,7 @@ Then force a new Cloud Run revision:
 
 ```bash
 gcloud run services update biocirv-prefect-worker \
-  --image=ghcr.io/sustainability-software-lab/ca-biositing/pipeline:latest --region=us-west1
+  --image=us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/pipeline:latest --region=us-west1
 ```
 
 #### Google Sheets / Drive authentication fails
@@ -694,5 +694,5 @@ Force a new revision:
 
 ```bash
 gcloud run services update biocirv-prefect-worker \
-  --image=ghcr.io/sustainability-software-lab/ca-biositing/pipeline:latest --region=us-west1
+  --image=us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/pipeline:latest --region=us-west1
 ```

--- a/deployment/cloud/gcp/infrastructure/artifact_registry.py
+++ b/deployment/cloud/gcp/infrastructure/artifact_registry.py
@@ -1,0 +1,30 @@
+"""Artifact Registry remote repository for proxying GHCR images."""
+
+import pulumi
+import pulumi_gcp as gcp
+
+from config import GCP_REGION
+
+
+def create_artifact_registry(depends_on=None):
+    """Create an AR remote repository that proxies GHCR.
+
+    Cloud Run only accepts images from gcr.io, docker.pkg.dev, or docker.io.
+    This remote repo lets Cloud Run pull GHCR images via AR transparently.
+    """
+    repo = gcp.artifactregistry.Repository(
+        "ghcr-proxy",
+        repository_id="ghcr-proxy",
+        location=GCP_REGION,
+        format="DOCKER",
+        mode="REMOTE_REPOSITORY",
+        remote_repository_config=gcp.artifactregistry.RepositoryRemoteRepositoryConfigArgs(
+            docker_repository=gcp.artifactregistry.RepositoryRemoteRepositoryConfigDockerRepositoryArgs(
+                custom_repository=gcp.artifactregistry.RepositoryRemoteRepositoryConfigDockerRepositoryCustomRepositoryArgs(
+                    uri="https://ghcr.io",
+                ),
+            ),
+        ),
+        opts=pulumi.ResourceOptions(depends_on=depends_on) if depends_on else None,
+    )
+    return repo

--- a/deployment/cloud/gcp/infrastructure/config.py
+++ b/deployment/cloud/gcp/infrastructure/config.py
@@ -28,13 +28,14 @@ READONLY_USERS = ["biocirv_readonly"]
 
 # Container images — override with env vars to use digest/commit-based tags
 # instead of :latest (which Pulumi cannot detect changes for).
-GHCR_BASE = "ghcr.io/sustainability-software-lab/ca-biositing"
+# Images are pulled via an Artifact Registry remote repo that proxies GHCR.
+AR_GHCR_BASE = f"us-west1-docker.pkg.dev/{GCP_PROJECT}/ghcr-proxy/sustainability-software-lab/ca-biositing"
 IMAGE_TAG = os.environ.get("IMAGE_TAG", "latest")
 WEBSERVICE_IMAGE = os.environ.get(
-    "WEBSERVICE_IMAGE", f"{GHCR_BASE}/webservice:{IMAGE_TAG}"
+    "WEBSERVICE_IMAGE", f"{AR_GHCR_BASE}/webservice:{IMAGE_TAG}"
 )
 PIPELINE_IMAGE = os.environ.get(
-    "PIPELINE_IMAGE", f"{GHCR_BASE}/pipeline:{IMAGE_TAG}"
+    "PIPELINE_IMAGE", f"{AR_GHCR_BASE}/pipeline:{IMAGE_TAG}"
 )
 PREFECT_SERVER_IMAGE = os.environ.get(
     "PREFECT_SERVER_IMAGE", "prefecthq/prefect:3-python3.12"

--- a/deployment/cloud/gcp/infrastructure/deploy.py
+++ b/deployment/cloud/gcp/infrastructure/deploy.py
@@ -19,6 +19,7 @@ from cloud_sql import create_cloud_sql
 from iam import create_service_accounts
 from secret_manager import create_secrets
 
+from artifact_registry import create_artifact_registry
 from cloud_run import create_cloud_run_resources
 from wif import create_wif
 
@@ -27,6 +28,11 @@ def pulumi_program():
     """Inline Pulumi program defining all GCP infrastructure."""
     # 1. Enable required GCP APIs — downstream resources depend on these.
     api_services = enable_apis()
+
+    # 1.5. Artifact Registry: remote repo proxying GHCR for Cloud Run
+    create_artifact_registry(
+        depends_on=[api_services["artifactregistry"]]
+    )
 
     # 2. Cloud SQL: instance, databases, users
     sql = create_cloud_sql(depends_on=[api_services["sqladmin"]])
@@ -41,7 +47,7 @@ def pulumi_program():
         depends_on=[api_services["iam"], api_services["cloudresourcemanager"]]
     )
 
-    # 5. Cloud Run: Services and Jobs (images pulled from GHCR)
+    # 5. Cloud Run: Services and Jobs (images pulled via AR remote repo)
     cr = create_cloud_run_resources(
         sql, secret_resources, iam, depends_on=[api_services["run"]]
     )

--- a/pixi.toml
+++ b/pixi.toml
@@ -360,7 +360,7 @@ cmd = "docker build -t ca-biositing-pulumi deployment/cloud/gcp/infrastructure/"
 description = "Build the Pulumi Docker image for infrastructure deployment."
 
 [feature.cloud.tasks.cloud-migrate]
-cmd = "gcloud run jobs update biocirv-alembic-migrate --image=ghcr.io/sustainability-software-lab/ca-biositing/pipeline:latest --region=us-west1 && gcloud run jobs execute biocirv-alembic-migrate --region=us-west1 --wait"
+cmd = "gcloud run jobs update biocirv-alembic-migrate --image=us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/pipeline:latest --region=us-west1 && gcloud run jobs execute biocirv-alembic-migrate --region=us-west1 --wait"
 description = "Refresh the migration job image digest and apply Alembic migrations."
 
 [feature.cloud.tasks.cloud-seed-admin]

--- a/scripts/cloud-migrate-ci.sh
+++ b/scripts/cloud-migrate-ci.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # IMAGE_TAG defaults to "latest" if not set in the environment.
 
 gcloud run jobs update biocirv-alembic-migrate \
-  --image="ghcr.io/sustainability-software-lab/ca-biositing/pipeline:${IMAGE_TAG:-latest}" \
+  --image="us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/pipeline:${IMAGE_TAG:-latest}" \
   --region=us-west1
 
 gcloud run jobs execute biocirv-alembic-migrate \

--- a/scripts/cloud-update-services.sh
+++ b/scripts/cloud-update-services.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # IMAGE_TAG defaults to "latest" if not set in the environment.
 
 gcloud run services update biocirv-prefect-worker \
-  --image="ghcr.io/sustainability-software-lab/ca-biositing/pipeline:${IMAGE_TAG:-latest}" \
+  --image="us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/pipeline:${IMAGE_TAG:-latest}" \
   --region=us-west1
 
 gcloud run services update biocirv-webservice \
-  --image="ghcr.io/sustainability-software-lab/ca-biositing/webservice:${IMAGE_TAG:-latest}" \
+  --image="us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/webservice:${IMAGE_TAG:-latest}" \
   --region=us-west1


### PR DESCRIPTION
## Summary

- Cloud Run rejects direct GHCR URLs — it only accepts images from `gcr.io`, `docker.pkg.dev`, or `docker.io`
- Creates an Artifact Registry remote repository (`ghcr-proxy`) via Pulumi that transparently proxies `ghcr.io`
- Updates all image references from `ghcr.io/sustainability-software-lab/ca-biositing/...` to `us-west1-docker.pkg.dev/biocirv-470318/ghcr-proxy/sustainability-software-lab/ca-biositing/...`

## Changes

| File | Change |
|------|--------|
| `artifact_registry.py` | **New** — AR remote repo resource |
| `deploy.py` | Wire in AR repo creation (step 1.5) |
| `config.py` | `GHCR_BASE` → `AR_GHCR_BASE` with AR URL |
| `scripts/cloud-migrate-ci.sh` | Update image URL |
| `scripts/cloud-update-services.sh` | Update image URLs |
| `pixi.toml` | Update `cloud-migrate` task image URL |
| `deployment/README.md` | Update image URLs in docs |

## Test plan

- [ ] `grep -rn "ghcr.io/sustainability-software-lab" --include="*.py" --include="*.sh" --include="*.toml"` returns no results
- [ ] Pulumi preview succeeds (creates AR repo resource)
- [ ] Deploy to staging — Cloud Run accepts AR image URLs