### PR TITLE
fix: grant deployer SA AR admin role and add Cloud Run→AR dependency

### DIFF
--- a/deployment/cloud/gcp/infrastructure/deploy.py
+++ b/deployment/cloud/gcp/infrastructure/deploy.py
@@ -30,7 +30,7 @@ def pulumi_program():
     api_services = enable_apis()
 
     # 1.5. Artifact Registry: remote repo proxying GHCR for Cloud Run
-    create_artifact_registry(
+    ghcr_proxy = create_artifact_registry(
         depends_on=[api_services["artifactregistry"]]
     )
 
@@ -49,7 +49,8 @@ def pulumi_program():
 
     # 5. Cloud Run: Services and Jobs (images pulled via AR remote repo)
     cr = create_cloud_run_resources(
-        sql, secret_resources, iam, depends_on=[api_services["run"]]
+        sql, secret_resources, iam,
+        depends_on=[api_services["run"], ghcr_proxy],
     )
 
     # 6. Workload Identity Federation for GitHub Actions CI/CD

--- a/deployment/cloud/gcp/infrastructure/wif.py
+++ b/deployment/cloud/gcp/infrastructure/wif.py
@@ -81,6 +81,7 @@ def create_wif(
         "roles/iam.serviceAccountAdmin",
         "roles/secretmanager.admin",
         "roles/resourcemanager.projectIamAdmin",
+        "roles/artifactregistry.admin",  # create/manage AR remote repos
     ]
 
     for role in deployer_roles:


### PR DESCRIPTION
## Summary

Fixes the deploy-staging failure from #193 — two issues:

- **IAM**: The deployer SA (`biocirv-staging-gh-deploy`) lacked `artifactregistry.repositories.create` permission. Added `roles/artifactregistry.admin` to the deployer role list in `wif.py`.
- **Dependency ordering**: Cloud Run resources (services/jobs) attempted to pull images from the AR repo before it was created. Added `ghcr_proxy` as an explicit dependency for `create_cloud_run_resources` in `deploy.py`.

## Test plan

- [ ] Pulumi preview succeeds (AR repo created before Cloud Run resources)
- [ ] deploy-staging workflow completes without permission errors