### PR TITLE
ci: add path filters to CD workflow for namespace packages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,9 +3,19 @@ name: CD
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - "src/ca_biositing/datamodels/**"
+      - "src/ca_biositing/pipeline/**"
+      - "src/ca_biositing/webservice/**"
+      - ".github/workflows/cd.yml"
   push:
     branches:
       - main
+    paths:
+      - "src/ca_biositing/datamodels/**"
+      - "src/ca_biositing/pipeline/**"
+      - "src/ca_biositing/webservice/**"
+      - ".github/workflows/cd.yml"
   release:
     types:
       - published


### PR DESCRIPTION
## Summary
- Add path filters to `pull_request` and `push` triggers in the CD workflow so it only runs when files under `src/ca_biositing/{datamodels,pipeline,webservice}/` or the workflow file itself change.
- `workflow_dispatch` and `release` triggers remain unfiltered.

## Test plan
- [ ] Verify CD workflow does not trigger on unrelated file changes (e.g., docs, infrastructure)
- [ ] Verify CD workflow triggers on changes to any of the three namespace packages
- [ ] Verify manual dispatch and release triggers still work