### PR TITLE
fix: reject unknown fields on PATCH /v1/auth/api-keys with 422

### DIFF
--- a/src/ca_biositing/webservice/ca_biositing/webservice/v1/auth/router.py
+++ b/src/ca_biositing/webservice/ca_biositing/webservice/v1/auth/router.py
@@ -245,7 +245,12 @@ def revoke_api_key(
     session: SessionDep,
     _admin: AdminUserDep,
 ) -> dict:
-    """Revoke an API key by setting is_active=False. Requires admin JWT authentication."""
+    """Soft-deactivate an API key (sets is_active=False). Requires admin JWT.
+
+    The key row is retained for audit purposes but rejected on all subsequent
+    authentication attempts. Deactivation is permanent via this API — to restore
+    access, issue a new key.
+    """
     key = session.exec(select(ApiKey).where(ApiKey.id == key_id)).first()
     if key is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")
@@ -263,7 +268,11 @@ def update_api_key(
     session: SessionDep,
     _admin: AdminUserDep,
 ) -> ApiKeyResponse:
-    """Update a key's name or rate limit. Requires admin JWT authentication."""
+    """Update a key's name or rate limit. Requires admin JWT authentication.
+
+    Only ``name`` and ``rate_limit_per_minute`` are accepted; any other field
+    (e.g. ``is_active``) returns 422. To deactivate a key, use DELETE.
+    """
     key = session.exec(select(ApiKey).where(ApiKey.id == key_id)).first()
     if key is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")

--- a/src/ca_biositing/webservice/ca_biositing/webservice/v1/auth/schemas.py
+++ b/src/ca_biositing/webservice/ca_biositing/webservice/v1/auth/schemas.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class Token(BaseModel):
@@ -82,7 +82,14 @@ class ApiKeyResponse(BaseModel):
 
 
 class ApiKeyUpdate(BaseModel):
-    """Payload for updating a key's label or rate limit."""
+    """Payload for updating a key's name or rate limit.
+
+    Only ``name`` and ``rate_limit_per_minute`` are mutable via PATCH.
+    To deactivate a key use DELETE (soft-deactivation); re-activation
+    requires issuing a new key.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = Field(default=None, min_length=1, max_length=128)
     rate_limit_per_minute: Optional[int] = Field(default=None, ge=0)

--- a/tests/webservice/v1/test_api_keys.py
+++ b/tests/webservice/v1/test_api_keys.py
@@ -328,6 +328,36 @@ class TestUpdateApiKey:
         assert body["name"] == "stable-name"
         assert body["rate_limit_per_minute"] == 90
 
+    def test_patch_is_active_returns_422(self, key_client, admin_token, admin_user):
+        """is_active is not a valid PATCH field — must return 422, not silently ignored."""
+        create_resp = key_client.post(
+            "/v1/auth/api-keys",
+            json={"name": "boundary-test", "api_user_id": admin_user.id, "rate_limit_per_minute": 60},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        key_id = create_resp.json()["id"]
+        patch_resp = key_client.patch(
+            f"/v1/auth/api-keys/{key_id}",
+            json={"is_active": False},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert patch_resp.status_code == 422
+
+    def test_patch_unknown_field_returns_422(self, key_client, admin_token, admin_user):
+        """Any unrecognised field in the PATCH body must return 422."""
+        create_resp = key_client.post(
+            "/v1/auth/api-keys",
+            json={"name": "boundary-test-2", "api_user_id": admin_user.id, "rate_limit_per_minute": 60},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        key_id = create_resp.json()["id"]
+        patch_resp = key_client.patch(
+            f"/v1/auth/api-keys/{key_id}",
+            json={"unknown_field": "value"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert patch_resp.status_code == 422
+
 
 class TestApiKeyAuthentication:
     """X-API-Key header authentication on protected endpoints."""

--- a/tests/webservice/v1/test_api_keys.py
+++ b/tests/webservice/v1/test_api_keys.py
@@ -335,6 +335,7 @@ class TestUpdateApiKey:
             json={"name": "boundary-test", "api_user_id": admin_user.id, "rate_limit_per_minute": 60},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
+        assert create_resp.status_code == 201
         key_id = create_resp.json()["id"]
         patch_resp = key_client.patch(
             f"/v1/auth/api-keys/{key_id}",
@@ -350,6 +351,7 @@ class TestUpdateApiKey:
             json={"name": "boundary-test-2", "api_user_id": admin_user.id, "rate_limit_per_minute": 60},
             headers={"Authorization": f"Bearer {admin_token}"},
         )
+        assert create_resp.status_code == 201
         key_id = create_resp.json()["id"]
         patch_resp = key_client.patch(
             f"/v1/auth/api-keys/{key_id}",


### PR DESCRIPTION
## Summary

- Adds `model_config = ConfigDict(extra="forbid")` to `ApiKeyUpdate` so clients that send `is_active` or any other unrecognised field receive a clear **422** instead of a misleading 200 with no visible effect
- Updates docstrings on both the `PATCH` and `DELETE` handlers to make the design boundary explicit: `DELETE` is the soft-deactivation mechanism; `PATCH` only mutates `name` and `rate_limit_per_minute`
- Adds 2 tests asserting the 422 behaviour (`test_patch_is_active_returns_422`, `test_patch_unknown_field_returns_422`)

## Background

Found during 100% coverage integration testing of PR #248. Sending `{"is_active": false}` to `PATCH /v1/auth/api-keys/{key_id}` returned HTTP 200 with the field unchanged — Pydantic was silently discarding the unknown field. After design review, `is_active` is intentionally immutable via PATCH (use `DELETE` to soft-deactivate). The fix makes this contract explicit at the API boundary.

## Test plan

- [ ] `pixi run pytest tests/webservice/v1/test_api_keys.py -v` — 16/16 pass (14 existing + 2 new)
- [ ] `pixi run pytest src/ca_biositing/webservice/tests/ tests/webservice/ -v` — full suite, no regressions
- [ ] Manual: `curl -X PATCH https://api-staging.calbioscape.org/v1/auth/api-keys/1 -H "Authorization: Bearer <admin_jwt>" -H "Content-Type: application/json" -d '{"is_active": false}'` → HTTP 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
