### PR TITLE
fix: Nulls to Zero or XRF an ICP

### DIFF
--- a/src/ca_biositing/pipeline/ca_biositing/pipeline/etl/transform/analysis/observation.py
+++ b/src/ca_biositing/pipeline/ca_biositing/pipeline/etl/transform/analysis/observation.py
@@ -54,6 +54,14 @@ def transform_observation(
         # Basic coercion for Observation fields
         if 'value' in df.columns:
             df = coercion_mod.coerce_columns(df, float_cols=['value'])
+            # User request: treat null as 0 for XRF and ICP if record_id is present
+            if 'analysis_type' in df.columns and 'record_id' in df.columns:
+                mask = df['analysis_type'].isin(['xrf analysis', 'icp analysis']) & df['record_id'].notna()
+                # Exception for ICP: do not convert nulls to 0 for "y-axial" and "y-radial" parameters
+                if 'parameter' in df.columns:
+                    icp_exception_mask = (df['analysis_type'] == 'icp analysis') & df['parameter'].isin(['y-axial', 'y-radial'])
+                    mask = mask & ~icp_exception_mask
+                df.loc[mask, 'value'] = df.loc[mask, 'value'].fillna(0)
 
         # Add lineage tracking if available
         df['etl_run_id'] = etl_run_id

--- a/src/ca_biositing/pipeline/ca_biositing/pipeline/etl/transform/analysis/xrf_record.py
+++ b/src/ca_biositing/pipeline/ca_biositing/pipeline/etl/transform/analysis/xrf_record.py
@@ -73,6 +73,10 @@ def transform_xrf_record(
         datetime_cols=['created_at', 'updated_at']
     )
 
+    # User request: treat null as 0 for XRF
+    if 'value' in coerced_df.columns:
+        coerced_df['value'] = coerced_df['value'].fillna(0)
+
     # 2. Normalization
     normalize_columns = {
         'resource': (Resource, 'name'),


### PR DESCRIPTION
## 📄 Description

This PR puts in logic for XRF and ICP analysis so that if there is a valid record_id, but value is NULL in the source data, then the null is converted to a 0 in the database. The frontend will handle converting this to "Not detected" or something similar.

The logic also excludes y-radial and y-axial from this conversion to 0.

## ✅ Checklist

- [x] I ran `pre-commit run --all-files` and all checks pass
- [ ] Tests added/updated where needed
- [ ] Docs added/updated if applicable
- [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

Resolves #332 

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [x]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

Run pipeline and check mv_biomass_composition for XRF values. Zero values will now appear for elements. Observations with 0 will also be present in the observation table

## 📝 Notes to reviewers


