### PR TITLE
Postgres DB Security hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 # Environment variables
 **/.env
 **/.env.*
+resources/docker/docker-compose.override.yml
 !**/.env.example
 
 # Python virtual environments

--- a/resources/docker/.env.example
+++ b/resources/docker/.env.example
@@ -11,7 +11,8 @@ POSTGRES_PASSWORD=biocirv_dev_password
 
 # 2. Host Port Mapping
 # This is the port on your local machine that will connect to the container's port 5432.
-POSTGRES_PORT=5432
+# Restricted to localhost (127.0.0.1) for security.
+POSTGRES_PORT=127.0.0.1:5432
 
 # 3. Application Database URL
 # This is the full connection string used by the Python application (e.g., SQLAlchemy, Alembic)

--- a/resources/docker/.env.example
+++ b/resources/docker/.env.example
@@ -11,8 +11,7 @@ POSTGRES_PASSWORD=biocirv_dev_password
 
 # 2. Host Port Mapping
 # This is the port on your local machine that will connect to the container's port 5432.
-# Restricted to localhost (127.0.0.1) for security.
-POSTGRES_PORT=127.0.0.1:5432
+POSTGRES_PORT=5432
 
 # 3. Application Database URL
 # This is the full connection string used by the Python application (e.g., SQLAlchemy, Alembic)

--- a/resources/docker/docker-compose.yml
+++ b/resources/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     env_file:
       - .env
     ports:
-      - "127.0.0.1:${POSTGRES_PORT}:5432"
+      - "${POSTGRES_PORT}:5432"
     shm_size: "1gb"
     volumes:
       - pgdata:/var/lib/postgresql/data

--- a/resources/docker/docker-compose.yml
+++ b/resources/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "127.0.0.1:${POSTGRES_PORT}:5432"
     shm_size: "1gb"
     volumes:
       - pgdata:/var/lib/postgresql/data


### PR DESCRIPTION
# 📄 Description

This PR hardens the security of the local development environment by restricting the PostgreSQL database to only listen on the `localhost` (127.0.0.1) interface. This resolves security alerts regarding the database being exposed to the local network.

**Key Changes:**
- Updated [`resources/docker/docker-compose.yml`](resources/docker/docker-compose.yml:9) to bind the database service specifically to `127.0.0.1`.
- Restored `POSTGRES_PORT` to a simple integer in [`.env.example`](resources/docker/.env.example:15) to maintain compatibility with Python/SQLAlchemy/Prefect (preventing `ValueError`).
- Added `docker-compose.override.yml` to [`.gitignore`](.gitignore:29) to allow developers to maintain persistent local security overrides across Git branches.

## ✅ Checklist

- [ ] I ran `pre-commit run --all-files` and all checks pass
- [ ] Tests added/updated where needed
- [x] Docs added/updated if applicable (Env examples updated)
- [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

Resolves security alert regarding local network exposure.

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (Security) | [x]      |

## 🧪 How to test

1.  Run `pixi run teardown-services` followed by `pixi run start-services`.
2.  Verify services start without `ValueError` by checking `pixi run service-status`.
3.  Check logs with `pixi run service-logs` to ensure `prefect-server` and `setup-db` successfully connected to the database.
4.  (Security verification) Try to connect to port 5432 using your machine's local IP address from a terminal or another device; connection should be refused.

## 📝 Notes to reviewers

This change strictly impacts local development Docker configurations. It does not affect Cloud SQL configurations used in staging or production, as those are managed independently via Pulumi.

---

I have updated your todo list to reflect the completion of the core tasks.

