### PR TITLE
fix(etl): include static data in production docker image

### DIFF
--- a/resources/docker/pipeline.dockerfile
+++ b/resources/docker/pipeline.dockerfile
@@ -33,6 +33,8 @@ COPY --from=build /app/alembic /app/alembic
 # copy Prefect flow entrypoint and deployment config
 COPY --from=build /app/resources/prefect/run_prefect_flow.py /app/run_prefect_flow.py
 COPY --from=build /app/resources/prefect/prefect.yaml /app/prefect.yaml
+# Copy static data needed for ETL
+COPY --from=build /app/data/static /app/data/static
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \


### PR DESCRIPTION
## Description
The Geography ETL flow fails in staging with because the static seeding .csv file is missing from the production Docker image.

## Changes
- Updated  to copy the  directory into the production stage.

## Verification
- Verified that the code in  expects the file at  relative to the workspace root.
- This change ensures the file is baked into the image, matching the structure used by the Prefect worker and Cloud Run.