### PR TITLE
Performance optimization for usda_census_view

### DIFF
--- a/src/ca_biositing/pipeline/ca_biositing/pipeline/etl/extract/usda_census_survey.py
+++ b/src/ca_biositing/pipeline/ca_biositing/pipeline/etl/extract/usda_census_survey.py
@@ -2,7 +2,9 @@
 USDA Census and Survey Data Extraction.
 
 This module extracts agricultural census and survey data from the USDA NASS
-Quick Stats API for California.
+Quick Stats API for all 58 California counties.
+The county list is driven by `data/static/ca_counties.csv`.
+
 Data includes:
 - Census data (every 5 years): Complete agricultural census
 - Survey data (annual): Preliminary and final agricultural estimates
@@ -13,6 +15,7 @@ For more information: https://quickstats.nass.usda.gov/api
 
 from typing import Optional
 import os
+from pathlib import Path
 import pandas as pd
 from prefect import task, get_run_logger
 
@@ -44,20 +47,33 @@ YEAR = None
 # Leave as None to get all commodities
 COMMODITY = None
 
-# North San Joaquin Valley priority counties (3-digit NASS county codes)
-# These match the counties used in the notebook
-PRIORITY_COUNTIES = {
-    "077",  # San Joaquin
-    "099",  # Stanislaus
-    "047",  # Merced
-}
+def _load_ca_counties() -> list:
+    """
+    Load all California counties from the static CSV file.
+    Returns a sorted list of (county_fips, county_name) tuples.
+    County FIPS codes are 3-digit zero-padded strings matching the USDA API county_code param.
+    """
+    # Try cwd-relative first (works in Docker where WORKDIR=/app)
+    cwd_path = Path.cwd() / "data" / "static" / "ca_counties.csv"
+    # Fallback: relative to this file (works in local dev)
+    file_path = Path(__file__).parents[9] / "data" / "static" / "ca_counties.csv"
+
+    csv_path = cwd_path if cwd_path.exists() else file_path
+    if not csv_path.exists():
+        raise FileNotFoundError(
+            f"ca_counties.csv not found. Tried:\n  {cwd_path}\n  {file_path}"
+        )
+
+    df = pd.read_csv(csv_path, dtype=str)
+    counties = sorted(zip(df["county_fips"], df["county_name"]))
+    return counties
 
 
 @task
 def extract() -> Optional[pd.DataFrame]:
     """
     Extracts USDA data ONLY for commodities mapped in resource_usda_commodity_map
-    and for priority counties (North San Joaquin Valley).
+    for all California counties.
     This allows adding new crops by updating the database, no code changes needed.
     """
     logger = get_run_logger()
@@ -76,36 +92,38 @@ def extract() -> Optional[pd.DataFrame]:
         )
         return None
 
-    logger.info(f"Extracting USDA data for {len(commodity_ids)} commodities in {len(PRIORITY_COUNTIES)} priority counties...")
+    ca_counties = _load_ca_counties()
+    logger.info(f"Loaded {len(ca_counties)} CA counties from ca_counties.csv")
+    logger.info(f"Extracting USDA data for {len(commodity_ids)} commodities for all counties in a single query per commodity...")
+    logger.info("Note: Optimized to 1 query per commodity instead of 1 per county/commodity")
 
-    # Collect data for all priority counties
-    all_dfs = []
+    # Call utility with commodity names, without county_code to get all counties at once
+    # This is much faster and stays well within rate limits
+    raw_df = usda_nass_to_df(
+        api_key=USDA_API_KEY,
+        state=STATE,
+        year=YEAR,
+        commodity_ids=commodity_ids,  # Database-driven commodity names
+        county_code=None  # Get all counties at once
+    )
 
-    for county_code in sorted(PRIORITY_COUNTIES):
-        logger.info(f"  Querying county {county_code}...")
-
-        # Call utility with commodity names and county filter
-        county_df = usda_nass_to_df(
-            api_key=USDA_API_KEY,
-            state=STATE,
-            year=YEAR,
-            commodity_ids=commodity_ids,  # Database-driven commodity names
-            county_code=county_code  # Limit to this county
-        )
-
-        if county_df is not None and not county_df.empty:
-            all_dfs.append(county_df)
-            logger.info(f"    Got {len(county_df)} records from county {county_code}")
-        else:
-            logger.warning(f"    No data for county {county_code}")
-
-    if not all_dfs:
-        logger.error("No data retrieved from any county. Aborting.")
+    if raw_df is None or raw_df.empty:
+        logger.error("No data retrieved from USDA NASS API. Aborting.")
         return None
 
-    # Combine all counties
-    raw_df = pd.concat(all_dfs, ignore_index=True)
-    logger.info(f"Successfully extracted {len(raw_df)} total records from USDA NASS API across {len(all_dfs)} counties.")
+    # Filter for the 58 California counties we care about (in case API returns others)
+    # The API 'county_code' is 3-digits.
+    valid_county_fips = {fips for fips, name in ca_counties}
+    initial_count = len(raw_df)
+    raw_df = raw_df[raw_df["county_code"].isin(valid_county_fips)]
+    filtered_count = len(raw_df)
+
+    logger.info(f"Filtered {initial_count} records down to {filtered_count} records for valid CA counties")
+
+    # Calculate how many counties actually returned data
+    counties_with_data = raw_df["county_code"].nunique()
+
+    logger.info(f"Successfully extracted {len(raw_df)} total records from USDA NASS API across {counties_with_data} of {len(ca_counties)} counties.")
 
     # 🔍 DIAGNOSTIC: Save raw extracted data for inspection (OPTIONAL - uncomment to enable)
     # Uncomment the following block to generate debug CSV files for troubleshooting

--- a/src/ca_biositing/pipeline/ca_biositing/pipeline/flows/usda_etl.py
+++ b/src/ca_biositing/pipeline/ca_biositing/pipeline/flows/usda_etl.py
@@ -27,7 +27,7 @@ def usda_etl_flow():
     etl_run_id = create_etl_run_record.fn(pipeline_name="USDA ETL")
     lineage_group_id = create_lineage_group.fn(
         etl_run_id=etl_run_id,
-        note="USDA Census/Survey agricultural data"
+        note="USDA Census/Survey agricultural data - all CA counties"
     )
     logger.info(f"✓ etl_run_id={etl_run_id}, lineage_group_id={lineage_group_id}")
 


### PR DESCRIPTION
## 📄 Description

This PR adds performance-optimizing indexes to the `usda_census_view` materialized view in the `ca_biositing` schema. These indexes target the specific query patterns used by the FastAPI service layer (e.g., in `usda_census_service.py`), which previously relied on full sequential scans.

**Key optimizations:**
- **`idx_usda_census_view_id` (UNIQUE)**: Enables `CONCURRENT` refresh of the materialized view.
- **`idx_usda_census_view_commodity_geoid`**: Covers the primary filtering path for county tooltips.
- **`idx_usda_census_view_commodity_geoid_year`**: Optimizes "latest record" lookups by ordering by year and ID.
- **`idx_usda_census_view_usda_crop` & `idx_usda_census_view_geoid`**: Speeds up discovery/listing endpoints.

**Technical changes:**
- Updated `scripts/compile_mv_fixes.py` to include `usda_census_view` and its index definitions.
- Generated migration `0019_add_indexes_to_usda_census_view.py`.

## ✅ Checklist

- [x] I ran `pre-commit run --all-files` and all checks pass
- [ ] Tests added/updated where needed
- [ ] Docs added/updated if applicable
- [ ] I have linked the issue this PR closes (if any)

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [x]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |

## 🧪 How to test

1. Run `pixi run migrate` to apply the new indexes.
2. Verify indexes exist: `pixi run access-db -c "\d ca_biositing.usda_census_view"`
3. Test API performance on census endpoints (e.g., `/v1/feedstocks/usda/census/crops/...`).
