### PR TITLE
fix: db reset script database connection and safety checks

### DIFF
--- a/resources/config/db_reset.yaml
+++ b/resources/config/db_reset.yaml
@@ -23,8 +23,8 @@ environments:
 
   production:
     host: ${DB_HOST_PROD:-localhost}
-    port: ${DB_PORT_PROD:-5433}
-    database: ${DB_NAME_PROD:-biocirv_production}
+    port: ${DB_PORT_PROD:-5435}
+    database: ${DB_NAME_PROD:-biocirv-production}
     postgres_user: ${DB_USER_PROD:-postgres}
     postgres_password: ${DB_PASSWORD_PROD:-${BIOCIRV_PRODUCTION_USER_PW}}
     admin_role: postgres

--- a/scripts/db_reset.py
+++ b/scripts/db_reset.py
@@ -157,6 +157,22 @@ class DatabaseResetOrchestrator:
                         user=user,
                         password=password
                     )
+                    # We must switch to the target database if we connected to postgres
+                    self.conn.autocommit = True
+                    with self.conn.cursor() as cur:
+                        cur.execute(f"SELECT 1 FROM pg_database WHERE datname = '{database}'")
+                        if not cur.fetchone():
+                            self.logger.info(f"Database {database} does not exist, creating it...")
+                            cur.execute(f"CREATE DATABASE \"{database}\"")
+                    self.conn.close()
+                    self.logger.info(f"Reconnecting to {database}...")
+                    self.conn = psycopg2.connect(
+                        host=host,
+                        port=port,
+                        database=database,
+                        user=user,
+                        password=password
+                    )
                 else:
                     raise e
 
@@ -168,9 +184,17 @@ class DatabaseResetOrchestrator:
     def validate_connection(self):
         """Validate database is accessible."""
         try:
+            assert self.conn is not None
             with self.conn.cursor() as cur:
                 cur.execute("SELECT version()")
-                self.logger.info(f"Database version: {cur.fetchone()[0]}")
+                row = cur.fetchone()
+                if row:
+                    self.logger.info(f"Database version: {row[0]}")
+
+                cur.execute("SELECT current_database()")
+                row = cur.fetchone()
+                if row:
+                    self.logger.info(f"Connected to database: {row[0]}")
         except psycopg2.Error as e:
             self.logger.error(f"Connection validation failed: {e}")
             raise
@@ -243,11 +267,23 @@ class DatabaseResetOrchestrator:
             return
 
         try:
+            # Type hint for Pylance
+            assert self.conn is not None
+
             with self.conn.cursor() as cur:
                 self.logger.info(f"Executing Phase {phase_num}: {sql_file}")
-                # Ensure we are operating on the correct database if we used fallback
-                # Note: Cloud SQL doesn't support CROSS-DATABASE queries, so we must be on the right DB.
-                # The SQL scripts themselves should be schema-qualified.
+
+                # Safety check: Ensure we are not accidentally wiping the 'postgres' database
+                # unless it is explicitly the target database.
+                cur.execute("SELECT current_database()")
+                row = cur.fetchone()
+                if row:
+                    current_db = row[0]
+                    target_db = self._expand_env_vars(self.env_config)['database']
+
+                    if current_db != target_db:
+                        raise RuntimeError(f"CRITICAL SAFETY ERROR: Connected to '{current_db}' but target is '{target_db}'. Aborting to prevent wiping wrong database.")
+
                 cur.execute(rendered_sql)
 
                 # Log any notices from PostgreSQL


### PR DESCRIPTION
## 📄 Description

This PR fixes issues with the database reset script (`scripts/db_reset.py`) and its configuration (`resources/config/db_reset.yaml`) that prevented successful resets of the production database.

Key changes:
- **Configuration Fix:** Corrected the default production database name in `db_reset.yaml` from `biocirv_production` to `biocirv-production` to match the actual database name.
- **Database Creation Fallback:** Updated `db_reset.py` so that if the primary connection fails and it falls back to connecting to the `postgres` database, it will now check if the target database exists and create it if it doesn't, before reconnecting to the target database.
- **Type Safety & Error Handling:** Added `assert self.conn is not None` for Pylance type checking and fixed potential `TypeError`s by properly checking the result of `cur.fetchone()` before subscripting it.

## ✅ Checklist

- [x] I ran `pre-commit run --all-files` and all checks pass
- [ ] Tests added/updated where needed
- [ ] Docs added/updated if applicable
- [ ] I have linked the issue this PR closes (if any)

## 🔗 Related Issues

N/A

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [x]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [ ]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

1. Attempt to run the database reset script against a target environment (e.g., production or staging).
2. Verify that the script successfully connects to the database (or creates it if it doesn't exist when falling back to the `postgres` db).
3. Verify that the schema wipe and reset process completes without errors.

## 📝 Notes to reviewers

The previous behavior caused the reset script to fail silently or throw errors when the target database didn't exist or when the connection fallback logic was triggered without properly switching to the target database context.